### PR TITLE
Fix warnings due to uninitialized Tcl variables

### DIFF
--- a/DESERT_Framework/DESERT/data_link/uw-smart-ofdm/uw-smart-ofdm-init.tcl
+++ b/DESERT_Framework/DESERT/data_link/uw-smart-ofdm/uw-smart-ofdm-init.tcl
@@ -59,3 +59,4 @@ Module/UW/SMART_OFDM set max_car_reserved_  4
 Module/UW/SMART_OFDM set print_transitions_ 0
 Module/UW/SMART_OFDM set max_burst_size_    1
 Module/UW/SMART_OFDM set fullBand_          0
+Module/UW/SMART_OFDM set nodenum_           0

--- a/DESERT_Framework/DESERT/data_link/uwjammer/uwjammer_default.tcl
+++ b/DESERT_Framework/DESERT/data_link/uwjammer/uwjammer_default.tcl
@@ -32,3 +32,4 @@
 PacketHeaderManager set tab_(PacketHeader/UW/JAMMER) 1
 
 Module/UW/JAMMER set buffer_data_pkts_              50
+Module/UW/JAMMER set debug_                         0

--- a/DESERT_Framework/DESERT/data_link/uwpolling/uwpolling_default.tcl
+++ b/DESERT_Framework/DESERT/data_link/uwpolling/uwpolling_default.tcl
@@ -48,6 +48,8 @@ Module/UW/POLLING/NODE set modem_data_bit_rate_ 1000
 Module/UW/POLLING/NODE set n_run                0
 Module/UW/POLLING/NODE set intra_data_guard_time_ 0.001
 Module/UW/POLLING/NODE set useAdaptiveTpoll_    0
+Module/UW/POLLING/NODE set node_id_              0
+Module/UW/POLLING/NODE set n_run_                0
 
 Module/UW/POLLING/AUV set max_payload_          125
 Module/UW/POLLING/AUV set T_probe_guard_        2
@@ -64,6 +66,9 @@ Module/UW/POLLING/AUV set max_buffer_size_	 	30
 Module/UW/POLLING/AUV set max_tx_pkts_ 			20
 Module/UW/POLLING/AUV set full_knowledge_       0
 Module/UW/POLLING/AUV set use_woss_             0
+Module/UW/POLLING/AUV set T_ack_timer_          20
+Module/UW/POLLING/AUV set n_run_                0
+Module/UW/POLLING/AUV set ack_enabled_          1
 
 Module/UW/POLLING/SINK set T_data_gurad 		10
 Module/UW/POLLING/SINK set backoff_tuner_		1

--- a/DESERT_Framework/DESERT/data_link/uwtdma-frame/uwtdma-frame-init.tcl
+++ b/DESERT_Framework/DESERT/data_link/uwtdma-frame/uwtdma-frame-init.tcl
@@ -30,8 +30,15 @@
 # Author: Roberto Francescon
 # version: 1.0.0
 
-Module/UW/TDMA_FRAME set debug_ 											0
-Module/UW/TDMA_FRAME set max_packet_per_slot                                1
+Module/UW/TDMA_FRAME set debug_			   0
+Module/UW/TDMA_FRAME set max_packet_per_slot       1
+Module/UW/TDMA_FRAME set queue_size_               10
+Module/UW/TDMA_FRAME set HDR_size_                 0
+Module/UW/TDMA_FRAME set drop_old_                 0
+Module/UW/TDMA_FRAME set checkPriority_            0
+Module/UW/TDMA_FRAME set mac2phy_delay_            [expr 1.0e-9]
+Module/UW/TDMA_FRAME set tot_slots                 0
+
 Module/UW/TDMA_FRAME instproc init {args} {
     $self next $args
     $self settag "UW/TDMA_FR"

--- a/DESERT_Framework/DESERT/data_link/uwtdma/uwtdma-init.tcl
+++ b/DESERT_Framework/DESERT/data_link/uwtdma/uwtdma-init.tcl
@@ -36,14 +36,14 @@ Module/UW/TDMA set HDR_size_ 		0
 Module/UW/TDMA set wait_constant_	0.1
 Module/UW/TDMA set MAC_addr_ 		0
 Module/UW/TDMA set sea_trial_ 		0
-Module/UW/TDMA set frame_duration   0
+Module/UW/TDMA set frame_duration       0
 Module/UW/TDMA set guard_time           0
 Module/UW/TDMA set tot_slots            0
 Module/UW/TDMA set fair_mode            0
 Module/UW/TDMA set max_packet_per_slot  1
 Module/UW/TDMA set queue_size_          10
 Module/UW/TDMA set drop_old_            0
-Module/UW/TDMA set checkPriority_		0
+Module/UW/TDMA set checkPriority_	0
 Module/UW/TDMA set mac2phy_delay_       [expr 1.0e-9]
 
 Module/UW/TDMA instproc init {args} {

--- a/DESERT_Framework/DESERT/interference/uwinterferenceofdm/uwinterferenceofdm_default.tcl
+++ b/DESERT_Framework/DESERT/interference/uwinterferenceofdm/uwinterferenceofdm_default.tcl
@@ -31,3 +31,4 @@
 Module/UW/INTERFERENCEOFDM set use_maxinterval_ 1 
 Module/UW/INTERFERENCEOFDM set maxinterval_ 50 
 Module/UW/INTERFERENCEOFDM set debug_ 0
+Module/UW/INTERFERENCEOFDM set inodeID_ 0

--- a/DESERT_Framework/DESERT/physical/uwhermesphy/uwhermesphy-default.tcl
+++ b/DESERT_Framework/DESERT/physical/uwhermesphy/uwhermesphy-default.tcl
@@ -30,10 +30,13 @@
 # @author Filippo Campagnaro
 # @version 1.0.0
 
-Module/UW/HERMES/PHY set tx_power_consumption_ 3.3
-Module/UW/HERMES/PHY set rx_power_consumption_ 0.620
-Module/UW/HERMES/PHY  set AcquisitionThreshold_dB_    15.0 
-Module/UW/HERMES/PHY  set MaxTxSPL_dB_               185.8
+Module/UW/HERMES/PHY set tx_power_consumption_        3.3
+Module/UW/HERMES/PHY set rx_power_consumption_        0.620
+Module/UW/HERMES/PHY set AcquisitionThreshold_dB_     15.0 
+Module/UW/HERMES/PHY set MaxTxSPL_dB_                 185.8
+Module/UW/HERMES/PHY set TxPower_                     5e9
+Module/UW/HERMES/PHY set NoiseSPD_                    [expr 1.28e-23 * 300]
+Module/UW/HERMES/PHY set ConsumedEnergy_              0
 
 Module/UW/HERMES/PHY  set BCH_N               15
 Module/UW/HERMES/PHY  set BCH_K               11

--- a/DESERT_Framework/DESERT/physical/uwofdmphy/uwofdmphy-default.tcl
+++ b/DESERT_Framework/DESERT/physical/uwofdmphy/uwofdmphy-default.tcl
@@ -47,3 +47,6 @@ Module/UW/OFDM/PHY  set BCH_T               1
 
 Module/UW/OFDM/PHY  set FRAME_BIT           9152
 
+Module/UW/OFDM/PHY set TxPower_             0.0
+Module/UW/OFDM/PHY set NoiseSPD_            0.001
+Module/UW/OFDM/PHY set ConsumedEnergy_      0.0

--- a/DESERT_Framework/DESERT/physical/uwoptical_phy/uwoptical-phy-default.tcl
+++ b/DESERT_Framework/DESERT/physical/uwoptical_phy/uwoptical-phy-default.tcl
@@ -38,4 +38,6 @@ Module/UW/OPTICAL/PHY set R_                                    [expr 1.49e9]
 Module/UW/OPTICAL/PHY set S_                                    0.26
 Module/UW/OPTICAL/PHY set T_                                    293.15
 Module/UW/OPTICAL/PHY set Ar_                                   0.0000011
+Module/UW/OPTICAL/PHY set NoiseSPD_                             0.01
 
+Module/UW/Optical/Channel set debug_                            0

--- a/DESERT_Framework/DESERT/physical/uwopticalbeampattern/uwopticalbeampattern-default.tcl
+++ b/DESERT_Framework/DESERT/physical/uwopticalbeampattern/uwopticalbeampattern-default.tcl
@@ -33,3 +33,5 @@
 PacketHeaderManager set tab_(PacketHeader/UWOPTICALBEAMPATTERN) 1
 
 Module/UW/UWOPTICALBEAMPATTERN set noise_threshold 0.001
+Module/UW/UWOPTICALBEAMPATTERN set NoiseSPD_       0.001
+Module/UW/UWOPTICALBEAMPATTERN set inclination_angle_ 0.0

--- a/DESERT_Framework/DESERT/physical/uwphysical/uwphysical-default.tcl
+++ b/DESERT_Framework/DESERT/physical/uwphysical/uwphysical-default.tcl
@@ -30,5 +30,19 @@
 # @author Giovanni Toso
 # @version 1.0.1
 
-Module/UW/PHYSICAL set tx_power_consumption_ 3.3
-Module/UW/PHYSICAL set rx_power_consumption_ 0.620
+Module/UW/PHYSICAL set tx_power_consumption_    3.3
+Module/UW/PHYSICAL set rx_power_consumption_    0.620
+Module/UW/PHYSICAL set NoiseSPD_                [expr 1.28e-23 * 300]
+Module/UW/PHYSICAL set AcquisitionThreshold_dB_ 0 
+Module/UW/PHYSICAL set MinTxSPL_dB_             10
+Module/UW/PHYSICAL set PER_target_              0.01
+Module/UW/PHYSICAL set RxSnrPenalty_dB_         -10
+Module/UW/PHYSICAL set TxSPLMargin_dB_          10
+Module/UW/PHYSICAL set ConsumedEnergy_          0
+Module/UW/PHYSICAL set MaxTxRange_              10000
+Module/UW/PHYSICAL set SPLOptimization_         0
+Module/UW/PHYSICAL set CentralFreqOptimization_ 0
+Module/UW/PHYSICAL set BandwidthOptimization_   0
+Module/UW/PHYSICAL set debug_                   0
+Module/UW/PHYSICAL set TxPower_                 5e9 
+Module/UW/PHYSICAL set BitRate_                 0

--- a/DESERT_Framework/DESERT/physical/uwphysicalnoise/uwphysicalnoise-default.tcl
+++ b/DESERT_Framework/DESERT/physical/uwphysicalnoise/uwphysicalnoise-default.tcl
@@ -31,5 +31,12 @@
 # @version 1.0.1
 
 Module/UW/PHYSICALNOISE set ship_stop			0
-Module/UW/PHYSICALNOISE set debug_noise_			0
+Module/UW/PHYSICALNOISE set debug_noise_		0
 Module/UW/PHYSICALNOISE set granularity			100
+Module/UW/PHYSICALNOISE set TxPower_                    5e9
+Module/UW/PHYSICALNOISE set NoiseSPD_                   [expr 1.28e-23 * 300]
+Module/UW/PHYSICALNOISE set BitRate_                    0
+Module/UW/PHYSICALNOISE set ConsumedEnergy_             0.0
+Module/UW/PHYSICALNOISE set rx_power_consumption_       0.0
+Module/UW/PHYSICALNOISE set tx_power_consumption_       0.0
+


### PR DESCRIPTION
The bounded varibales need to be initialized in the dedicated Tcl file. Fix #2 